### PR TITLE
Restart k3s service when tunnel changes

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -125,6 +125,7 @@ def sync_wireguard_config(channel, private_key_s):
 
     if wg_restart:
         restart_service("wireguard")
+        restart_service("k3s")
 
 
 def sync_device_name(hardware, balena_device_name):


### PR DESCRIPTION
Restarting k3s will importantly kill the calico-node process, and
when it starts again, calico-node will understand the IP is now
different.

This is a sledgehammer approach -- I'm also not sure it will work
properly given the contract constraints in use now.