### PR TITLE
copy containerd config to volume at runtime

### DIFF
--- a/k3s-t186/Dockerfile.xavier-nx-devkit-emmc
+++ b/k3s-t186/Dockerfile.xavier-nx-devkit-emmc
@@ -25,9 +25,9 @@ RUN install_packages wget tar lbzip2 python3 libegl1 && \
 
 COPY --from=build /usr/local/bin/k3s /usr/local/bin/k3s
 
-# Override default containerd config.toml with template file.
+# Override default containerd config.toml with template file. This is copied into the config volume by start.sh
 # Copied from https://github.com/k3s-io/k3s/blob/master/pkg/agent/templates/templates_linux.go
-COPY config.toml.tmpl /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+COPY config.toml.tmpl /docker/config.toml.tmpl
 
 COPY start.sh /docker/start.sh
 CMD ["/docker/start.sh"]

--- a/k3s-t186/start.sh
+++ b/k3s-t186/start.sh
@@ -20,6 +20,10 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
 fi
 
+# Copy config.toml.tmpl from image into config volume. Necessary to set default runtime to nvidia
+# and config file is shadowed otherwise.
+cp /docker/config.toml.tmpl /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+
 k3s agent \
   --kubelet-arg=volume-plugin-dir=/opt/libexec/kubernetes/kubelet-plugins/volume/exec \
   "$@"


### PR DESCRIPTION
This ensures the containerd override is copied into the config volume at runtime.
This cannot be done during docker build, as the config volume will shadow it.

This resolves https://github.com/ChameleonCloud/chi-edge-workers/issues/2