### PR TITLE
move l4t installation to script, remove extra cuda-toolkit

### DIFF
--- a/k3s-t186/Dockerfile.xavier-nx-devkit-emmc
+++ b/k3s-t186/Dockerfile.xavier-nx-devkit-emmc
@@ -1,29 +1,30 @@
-FROM balenalib/jetson-xavier-nx-devkit-emmc-ubuntu:bionic-build-20220320 as build
+ARG BASE_IMAGE=balenalib/jetson-xavier-nx-devkit-emmc-ubuntu
+
+FROM ${BASE_IMAGE}:bionic-build-20220320 as k3s-build
 
 ARG K3S_VERSION=v1.22.5%2Bk3s1
 
 COPY install-k3s.sh /docker/install-k3s.sh
 RUN /docker/install-k3s.sh "aarch64"
 
-FROM balenalib/jetson-xavier-nx-devkit-emmc-ubuntu:bionic-run-20220320 as run
-RUN install_packages nvidia-container-runtime cuda-toolkit-10-2
+FROM ${BASE_IMAGE}:bionic-run-20220320 as run
+RUN install_packages \
+    binutils \
+    lbzip2 \
+    libegl1 \
+    python3 \
+    tar \
+    wget \
+    xz-utils
 
-# Download and install BSP binaries for L4T 32.6.1
-RUN install_packages wget tar lbzip2 python3 libegl1 && \
-    wget https://developer.nvidia.com/embedded/l4t/r32_release_v6.1/t186/jetson_linux_r32.6.1_aarch64.tbz2 && \
-    tar xf jetson_linux_r32.6.1_aarch64.tbz2 && \
-    cd Linux_for_Tegra && \
-    sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
-    sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \
-    sed -i 's/LC_ALL=C chroot . mount -t proc none \/proc/ /g' nv_tegra/nv-apply-debs.sh && \
-    sed -i 's/umount ${L4T_ROOTFS_DIR}\/proc/ /g' nv_tegra/nv-apply-debs.sh && \
-    sed -i 's/chroot . \//  /g' nv_tegra/nv-apply-debs.sh && \
-    ./apply_binaries.sh -r / --target-overlay && cd .. \
-    rm -rf jetson_linux_r32.6.1_aarch64.tbz2 && \
-    rm -rf Linux_for_Tegra && \
-    echo "/usr/lib/aarch64-linux-gnu/tegra" > /etc/ld.so.conf.d/nvidia-tegra.conf && ldconfig
+# BSP binaries for L4T 32.6.1
+RUN install_packages \
+    nvidia-container-runtime
 
-COPY --from=build /usr/local/bin/k3s /usr/local/bin/k3s
+COPY install_tegra.sh /docker/install_tegra.sh
+RUN /docker/install_tegra.sh
+
+COPY --from=k3s-build /usr/local/bin/k3s /usr/local/bin/k3s
 
 # Override default containerd config.toml with template file. This is copied into the config volume by start.sh
 # Copied from https://github.com/k3s-io/k3s/blob/master/pkg/agent/templates/templates_linux.go

--- a/k3s-t186/install_tegra.sh
+++ b/k3s-t186/install_tegra.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "downloading binaries"
+wget "https://developer.nvidia.com/embedded/l4t/r32_release_v6.1/t186/jetson_linux_r32.6.1_aarch64.tbz2" && \
+    tar -xf "jetson_linux_r32.6.1_aarch64.tbz2" && \
+    rm -f "jetson_linux_r32.6.1_aarch64.tbz2"
+
+echo "find and replace"
+cd Linux_for_Tegra && \
+    sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
+    sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \
+    sed -i 's/LC_ALL=C chroot . mount -t proc none \/proc/ /g' nv_tegra/nv-apply-debs.sh && \
+    sed -i 's/umount ${L4T_ROOTFS_DIR}\/proc/ /g' nv_tegra/nv-apply-debs.sh && \
+    sed -i 's/chroot . \//  /g' nv_tegra/nv-apply-debs.sh
+
+echo "applying binaries"
+./apply_binaries.sh -r / --target-overlay && cd ..
+rm -rf Linux_for_Tegra
+
+echo "adding kernel module config"
+echo "/usr/lib/aarch64-linux-gnu/tegra" > /etc/ld.so.conf.d/nvidia-tegra.conf && ldconfig


### PR DESCRIPTION
this ensures the l4t installation steps are completed in one layer, saving 600mb.
In addition, the cuda-toolkit is not needed, reducing final image size by 4gb.